### PR TITLE
修复：bool AudioTokenizerDecoder::load_model(const std::string & model_path) 中的变量 'n' 未定义，以避免未定义行为

### DIFF
--- a/src/audio_tokenizer_decoder.cpp
+++ b/src/audio_tokenizer_decoder.cpp
@@ -158,7 +158,7 @@ bool AudioTokenizerDecoder::load_model(const std::string & model_path) {
             }
         }
         else {
-            int blk_idx, res_idx, cb_idx, n;
+            int blk_idx, res_idx, cb_idx, n = 0;
             char suffix[64];
             size_t name_len = strlen(name);
             


### PR DESCRIPTION
## 问题描述

在 `AudioTokenizerDecoder::load_model` 函数中，用于 `sscanf %n` 的变量 `n` 未被初始化：
这导致在 Release 模式下（Debug 模式因内存清零可能侥幸通过）：

- MATCH1 宏中的 (size_t)n == name_len 条件可能意外成立
- 张量名称匹配错误（例如 conv_t.weight 被误判为 snake.alpha）
- 最终 model_.dec_blocks[i].conv_t_w 保持为 nullptr
- 在 apply_decoder_block 中解引用空指针 → 段错误（Segmentation Fault）
    
## 修复方案

`int n = 0;`
确保 sscanf %n 行为可预测，只有完整匹配时才认为成功。

## 测试验证

- Debug 模式下 TTS 生成正常  
- Release 模式下不再崩溃，音频成功生成  
- 所有 decoder 张量（conv_t_w, snake_alpha 等）均正确加载
    
## 影响范围

仅修改模型加载逻辑，无 API 变更，不影响其他功能。