### PR TITLE
fix(build): enable PIC for static libs so shared lib links on Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,9 @@ project(qwen3-tts-ggml VERSION 0.1.0 LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+# Static libs are linked into the qwen3tts shared lib (C API), so they must be PIC
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
 # Compiler flags
 if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wpedantic")


### PR DESCRIPTION
The libqwen3tts shared library (added in 63c27a5 for the C API) fails to link on Linux x86_64 because the static libs it consumes are not compiled with -fPIC. macOS does not enforce this restriction, so the issue is Linux-specific:

  /usr/bin/ld: libqwen3_tts.a(qwen3_tts.cpp.o): relocation R_X86_64_PC32
  against symbol stderr@@GLIBC_2.2.5 can not be used when making a
  shared object; recompile with -fPIC

Adding set(CMAKE_POSITION_INDEPENDENT_CODE ON) makes every target PIC. Harmless for the CLI and static libs when consumed by the executable; required for the qwen3tts_shared SHARED target.

---
In the spirit of transparency, i'm not an experience C++ developer and this fix was produced by claude when I was diagnosing why the build on my linux machine was failing. Happy to contribute any further information if it helps.